### PR TITLE
Revert "Translate all the menus to English"

### DIFF
--- a/docs/advance-usage/_category_.json
+++ b/docs/advance-usage/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Advanced",
+  "label": "进阶使用",
   "position": 4,
   "link": {
     "type": "generated-index",

--- a/docs/advance-usage/create-tasks/_category_.json
+++ b/docs/advance-usage/create-tasks/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Create Task",
+  "label": "创建任务",
   "position": 4,
   "link": {
     "type": "generated-index",

--- a/docs/advance-usage/fedreated-learning/_category_.json
+++ b/docs/advance-usage/fedreated-learning/_category_.json
@@ -1,8 +1,8 @@
 {
-  "label": "Federated Learning",
+  "label": "联邦学习",
   "position": 6,
   "link": {
     "type": "generated-index",
-    "description": "学习如何使用 PrimiHub 进行更复杂的操作"
+    "description": "学习如何使用PrimiHub进行更复杂的操作"
   }
 }

--- a/docs/advance-usage/security-protocol/_category_.json
+++ b/docs/advance-usage/security-protocol/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Security Protocol",
+  "label": "安全协议",
   "position": 5,
   "link": {
     "type": "generated-index",

--- a/docs/core-concept/_category_.json
+++ b/docs/core-concept/_category_.json
@@ -1,8 +1,8 @@
 {
-  "label": "Core Concept",
+  "label": "核心特性",
   "position": 3,
   "link": {
     "type": "generated-index",
-    "description": "了解 PrimiHub 的核心特性"
+    "description": "了解PrimiHub的核心特性"
   }
 }

--- a/docs/developer-docs/_category_.json
+++ b/docs/developer-docs/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Developer Guide",
+  "label": "开发者文档",
   "position": 5,
   "link": {
     "type": "generated-index",

--- a/docs/developer-docs/deployment/_category_.json
+++ b/docs/developer-docs/deployment/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Deployment",
+  "label": "部署",
   "position": 3,
   "link": {
     "type": "generated-index",

--- a/docs/developer-docs/privacy-platform/_category_.json
+++ b/docs/developer-docs/privacy-platform/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Platform",
+  "label": "管理平台",
   "position": 4,
   "link": {
     "type": "generated-index",

--- a/docs/quick-start-platform/_category_.json
+++ b/docs/quick-start-platform/_category_.json
@@ -1,7 +1,6 @@
 {
-  "label": "Try It",
+  "label": "快速试用管理平台",
   "position": 2,
-  "collapsed": false,
   "link": {
     "type": "generated-index",
     "description": " "


### PR DESCRIPTION
Reverts primihub/primihub-docs#49 due to it will cause a wrong menu translation. See also

![image](https://user-images.githubusercontent.com/1450685/196123921-54d5b128-5741-41ee-bcf3-93315b34b4b1.png)
